### PR TITLE
Binary tree postorder traversal

### DIFF
--- a/data-structures/binary_tree/ruby/inorder_traversal.rb
+++ b/data-structures/binary_tree/ruby/inorder_traversal.rb
@@ -26,9 +26,10 @@
 # @return {Integer[]}
 def inorder_traversal(root)
   curr = root
-  stack, res = [], []
+  stack = []
+  res = []
 
-  while !(curr.nil? and stack.empty?)
+  until curr.nil? && stack.empty?
     while curr
       stack.push(curr)
       curr = curr.left
@@ -38,7 +39,7 @@ def inorder_traversal(root)
     curr = curr.right
   end
 
-  return res
+  res
 end
 
 # Approach 2: Recursive
@@ -56,7 +57,7 @@ end
 def inorder_traversal_recursive(root)
   response = []
   traverse(root, response)
-  return response
+  response
 end
 
 def traverse(node, response)
@@ -88,7 +89,7 @@ end
 def inorder_traversal(root)
   result = []
   iterator = root
-  while iterator do
+  while iterator
     if iterator.left.nil?
       result << iterator.val
       iterator = iterator.right
@@ -110,8 +111,6 @@ end
 def find_predecessor(node)
   current_node = node
   node = node.left
-  while node.right and node.right != current_node do
-    node = node.right
-  end
+  node = node.right while node.right && (node.right != current_node)
   node
 end

--- a/data-structures/binary_tree/ruby/postorder_traversal.rb
+++ b/data-structures/binary_tree/ruby/postorder_traversal.rb
@@ -44,7 +44,7 @@ def postorder_traversal(root)
   array = []
   stack = [root]
 
-  while not stack.empty? do
+  until stack.empty?
     node = stack.pop
     array.unshift(node.val)
 
@@ -68,14 +68,15 @@ end
 # @param {TreeNode} root
 # @return {Integer[]}
 def postorder_traversal(root)
-    return [] if root.nil?
-    values = []
-    traversal(root,values)
-    return values
+  return [] if root.nil?
+
+  values = []
+  traversal(root, values)
+  values
 end
 
-def traversal(root,values)
-    traversal(root.left,values) if root.left
-    traversal(root.right,values) if root.right
-    values << root.val
+def traversal(root, values)
+  traversal(root.left, values) if root.left
+  traversal(root.right, values) if root.right
+  values << root.val
 end

--- a/data-structures/binary_tree/ruby/postorder_traversal.rb
+++ b/data-structures/binary_tree/ruby/postorder_traversal.rb
@@ -1,0 +1,81 @@
+# Given the root of a binary tree, return the postorder traversal of its nodes' values.
+
+# Input: root = [1,null,2,3]
+# Output: [3,2,1]
+
+# Input: root = []
+# Output: []
+
+# Input: root = [1]
+# Output: [1]
+
+# Input: root = [1,2]
+# Output: [2,1]
+
+# Input: root = [1,null,2]
+# Output: [2,1]
+
+# Definition for a binary tree node.
+class TreeNode
+  attr_accessor :val, :left, :right
+
+  def initialize(val = 0, left = nil, right = nil)
+    @val = val
+    @left = left
+    @right = right
+  end
+end
+
+# Approach 1: Interative
+
+# Complexity Analysis
+
+# Time complexity: O(N), where N is the number of nodes.
+# We visit each node exactly once, thus the time complexity is O(N).
+
+# Space complexity: O(N). Up to O(H) to keep the stack,
+# where H is a tree height. In the worst case of the skewed tree H = N.
+
+# @param {TreeNode} root
+# @return {Integer[]}
+def postorder_traversal(root)
+  return [] unless root
+
+  array = []
+  stack = [root]
+
+  while not stack.empty? do
+    node = stack.pop
+    array.unshift(node.val)
+
+    stack.push(node.left) if node.left
+    stack.push(node.right) if node.right
+  end
+
+  array
+end
+
+# Approach 2: Recursive
+
+# Complexity Analysis
+
+# Time complexity: O(N), where N is the number of nodes.
+# We visit each node exactly once, thus the time complexity is O(N).
+
+# Space complexity: O(N). Up to O(H) to keep the stack,
+# where H is a tree height. In the worst case of the skewed tree H = N.
+
+# @param {TreeNode} root
+# @return {Integer[]}
+def postorder_traversal(root)
+    return [] if root.nil?
+    values = []
+    traversal(root,values)
+    return values
+end
+
+def traversal(root,values)
+    traversal(root.left,values) if root.left
+    traversal(root.right,values) if root.right
+    values << root.val
+end

--- a/data-structures/binary_tree/ruby/preorder_traversal.rb
+++ b/data-structures/binary_tree/ruby/preorder_traversal.rb
@@ -52,9 +52,9 @@ end
 # Space complexity: depending on the tree structure, we could keep up to the entire tree,
 # therefore, the space complexity is `O(N)`.
 
-# 
+#
 # Approach 1: Iterative
-# 
+#
 
 # @param {TreeNode} root
 # @return {Integer[]}
@@ -75,21 +75,22 @@ def preorder_traversal(root)
   results
 end
 
-# 
+#
 # Approach 2: Recursive Ruby Solution
-# 
+#
 # @param {TreeNode} root
 # @return {Array[]}
 def preorder_traversal(root)
   ans = []
-  return ans if root == nil
+  return ans if root.nil?
+
   ans << root.val << preorder_traversal(root.left) << preorder_traversal(root.right)
   ans.flatten
 end
 
-# 
+#
 # Approach 3: Morris traversal
-# 
+#
 # This approach is based on Morris's article which is intended to optimize the space
 # complexity. The algorithm does not use additional space for the computation, and
 # the memory is only used to keep the output. If one prints the output directly
@@ -120,7 +121,7 @@ end
 def preorder_traversal(root)
   result = []
   iterator = root
-  while iterator do
+  while iterator
     if iterator.left.nil?
       result << iterator.val
       iterator = iterator.right
@@ -142,8 +143,6 @@ end
 def find_predecessor(node)
   current_node = node
   node = node.left
-  while node.right and node.right != current_node do
-    node = node.right
-  end
+  node = node.right while node.right && (node.right != current_node)
   node
 end


### PR DESCRIPTION
Given the root of a binary tree, return the postorder traversal of its nodes' values.

```
# Input: root = [1,null,2,3]
# Output: [3,2,1]

# Input: root = []
# Output: []

# Input: root = [1]
# Output: [1]

# Input: root = [1,2]
# Output: [2,1]

# Input: root = [1,null,2]
# Output: [2,1]
```