### PR TITLE
Binary tree level order traversal

### DIFF
--- a/data-structures/binary_tree/README.md
+++ b/data-structures/binary_tree/README.md
@@ -1,22 +1,12 @@
 # Binary Trees
 
 - [Binary Trees](#binary-trees)
-  - [In-order](#in-order)
-  - [Post-order](#post-order)
-  - [Pre-order](#pre-order)
+  - [Complexity Analysis](#complexity-analysis)
 
-### In-order
+## Complexity Analysis
 
-- [C](c/inorder.c)
+As we mentioned before, we can traverse a tree recursively to retrieve all the data in pre-order, in-order or post-order. The time complexity is `O(N)` because we visit each node exactly once. And the depth of the tree might be `N` in the worst case. That is to say, the level of recursion might be at most N in the worst case. Therefore, taking system stack into consideration, the space complexity is `O(N)` as well.
 
----
+To be cautious, the complexity might be different due to a different implementation. It is comparatively easy to do traversal recursively but when the depth of the tree is too large, we might suffer from stack overflow problem. That's one of the main reasons why we want to solve this problem iteratively sometimes.
 
-### Post-order
-
-- [C](c/postorder.c)
-
----
-
-### Pre-order
-
-- [C](c/preorder.c)
+For the iterative solution, the time complexity is apparently the same with recursion solution which is `O(N)`. The space complexity is also `O(N)` since in the worst case, we will have all the nodes in the stack. There are some other solutions for iterative traversal which can reduce the space complexity to `O(1)`.

--- a/data-structures/binary_tree/ruby/level_order_traversal.rb
+++ b/data-structures/binary_tree/ruby/level_order_traversal.rb
@@ -3,6 +3,12 @@
 
 # For example:
 # Given binary tree [3,9,20,null,null,15,7],
+# return its level order traversal as:
+# [
+#   [3],
+#   [9,20],
+#   [15,7]
+# ]
 
 class TreeNode
   attr_accessor :val, :left, :right

--- a/data-structures/binary_tree/ruby/level_order_traversal.rb
+++ b/data-structures/binary_tree/ruby/level_order_traversal.rb
@@ -1,0 +1,102 @@
+# Given a binary tree, return the level order traversal of its nodes' values.
+# (i.e: from left to right, level by level).
+
+# For example:
+# Given binary tree [3,9,20,null,null,15,7],
+
+class TreeNode
+  attr_accessor :val, :left, :right
+
+  def initialize(val)
+    @val = val
+    @left = nil
+    @right = nil
+  end
+end
+
+#
+# Approach 1: Recursive
+#
+
+# Algorithm
+#
+# The simplest way to solve the problem is to use a recursion.
+# Let's first ensure that the tree is not empty, and then call recursively the function
+# helper(node, level), which takes the current node and its level as the arguments.
+# This function does the following:
+# The output list here is called levels, and hence the current level is just a length of
+# this list len(levels). Compare the number of a current level len(levels) with a node
+# level. If you're still on the previous level - add the new one by adding a new list into levels.
+# Append the node value to the last list in levels.
+# Process recursively child nodes if they are not None : helper(node.left / node.right, level + 1).
+#
+
+# Complexity Analysis
+
+# Time complexity: O(N) since each node is processed exactly once.
+# Space complexity: O(N) to keep the output structure which contains N node values.
+
+def level_order(root)
+  result = []
+  return result if root.nil?
+
+  inner_level_order(root, 0, result)
+  result
+end
+
+def inner_level_order(root, level, result)
+  result[level] ||= []
+  result[level] << root.val
+  inner_level_order(root.left, level + 1, result) unless root.left.nil?
+  inner_level_order(root.right, level + 1, result) unless root.right.nil?
+end
+
+#
+# Approach 2: Iterative
+#
+
+# Algorithm
+#
+# The recursion above could be rewritten in the iteration form.
+# Let's keep nodes of each tree level in the queue structure, which typically orders
+# elements in a FIFO (first-in-first-out) manner. In Java one could use LinkedList
+# implementation of the Queue interface. In Python using Queue structure would be an overkill
+# since it's designed for a safe exchange between multiple threads and hence requires
+# locking which leads to a performance loose. In Python the queue implementation with a
+# fast atomic append() and popleft() is deque.
+# The zero level contains only one node root. The algorithm is simple:
+# Initiate queue with a root and start from the level number 0 : level = 0.
+# While queue is not empty:
+# Start the current level by adding an empty list into output structure levels.
+# Compute how many elements should be on the current level : it's a queue length.
+# Pop out all these elements from the queue and add them into the current level.
+# Push their child nodes into the queue for the next level.
+# Go to the next level level++.
+#
+
+# Complexity Analysis
+
+# Time complexity: O(N) since each node is processed exactly once.
+# Space complexity: O(N) to keep the output structure which contains N node values.
+
+# @param {TreeNode} root
+# @return {Integer[][]}
+def level_order(root)
+  return [] unless root
+
+  arr = [root]
+  order = [[root.val]]
+  while arr.size > 0
+    width = arr.size
+    temp = []
+    (0...width).each do |_i|
+      node = arr.shift
+      arr.push(node.left) unless node&.left.nil?
+      arr.push(node.right) unless node&.right.nil?
+      temp << node.left.val unless node&.left.nil?
+      temp << node.right.val unless node&.right.nil?
+    end
+    order << temp unless temp.empty?
+  end
+  order
+end


### PR DESCRIPTION
Given a binary tree, return the level order traversal of its nodes' values.
(i.e: from left to right, level by level).

```
For example: Given binary tree [3,9,20,null,null,15,7],

  9   15
 /   /
3 - 20
     \
      7

return its level order traversal as:
[
  [3],
  [9,20],
  [15,7]
]
```